### PR TITLE
Improve compatibility of GraphitiErrors.enable!/disable!

### DIFF
--- a/lib/graphiti/rails/graphiti_errors_testing.rb
+++ b/lib/graphiti/rails/graphiti_errors_testing.rb
@@ -4,24 +4,14 @@ module Graphiti
       include RescueRegistry::RailsTestHelpers
 
       def enable!
-        DEPRECATOR.deprecation_warning("GraphitiError.enable! in tests", "Use RescueRegistry::RailsTestHelpers#handle_request_exceptions instead.")
-
+        DEPRECATOR.deprecation_warning("GraphitiError.enable! in tests", "This method may cause leaked behavior between tests! Wrap in RescueRegistry::RailsTestHelpers#handle_request_exceptions instead.")
         super
-
-        if @original_show_exceptions.nil?
-          @original_show_exceptions = handle_request_exceptions?
-        end
-
         handle_request_exceptions(true)
       end
 
       def disable!
-        DEPRECATOR.deprecation_warning("GraphitiError.disable! in tests", "Use RescueRegistry::RailsTestHelpers#handle_request_exceptions(false), instead. Note that exceptions are no longer caught by default during testing.")
-
-        unless @original_show_exceptions.nil?
-          handle_request_exceptions(@original_show_exceptions)
-          @original_show_exceptions = nil
-        end
+        DEPRECATOR.deprecation_warning("GraphitiError.disable! in tests", "This method may cause leaked behavior between tests! Wrap in RescueRegistry::RailsTestHelpers#handle_request_exceptions instead. Note that exceptions are no longer caught by default during testing.")
+        handle_request_exceptions(false)
       ensure
         super
       end


### PR DESCRIPTION
This allows for more uses to work as expected. However, it does come
with an increased risk of potential leaked behavior between tests.