### PR TITLE
Do not depend on ActiveRecord for route generators

### DIFF
--- a/lib/generators/graphiti/resource_generator.rb
+++ b/lib/generators/graphiti/resource_generator.rb
@@ -132,10 +132,7 @@ module Graphiti
     end
 
     def generate_route
-      # Rails 5.2 adds `plural_route_name`, fallback to `plural_table_name`
-      plural_name = try(:plural_route_name) || plural_table_name
-
-      code = "resources :#{plural_name}"
+      code = "resources :#{file_name.pluralize}"
       code << %(, only: [#{actions.map { |a| ":#{a}" }.join(", ")}]) if actions.length < 5
       code << "\n"
       inject_into_file "config/routes.rb", after: /ApplicationResource.*$\n/ do


### PR DESCRIPTION
The generators currently fail in rails applications which are not using
activerecord, as the previous version relied on the table name
pluralization logic from that library.  This changes to use the simpler
version which matches the way rails' default routes generator handles it.