### PR TITLE
Do not enable the debugger if the user has explicitly disabled it

### DIFF
--- a/lib/graphiti/rails/railtie.rb
+++ b/lib/graphiti/rails/railtie.rb
@@ -37,7 +37,7 @@ module Graphiti
 
       initializer "graphti-rails.logger" do
         config.after_initialize do
-          debugger_enabled = ENV.fetch('GRAPHITI_DEBUG', Graphiti.config.debug)
+          debugger_enabled = ENV.fetch['GRAPHITI_DEBUG'] == 'false' || Graphiti.config.debug
           Graphiti.config.debug = debugger_enabled && ::Rails.logger.level.zero?
           Graphiti.logger = ::Rails.logger
         end

--- a/lib/graphiti/rails/railtie.rb
+++ b/lib/graphiti/rails/railtie.rb
@@ -37,7 +37,8 @@ module Graphiti
 
       initializer "graphti-rails.logger" do
         config.after_initialize do
-          Graphiti.config.debug = ::Rails.logger.level.zero?
+          debugger_enabled = ENV.fetch('GRAPHITI_DEBUG', Graphiti.config.debug)
+          Graphiti.config.debug = debugger_enabled && ::Rails.logger.level.zero?
           Graphiti.logger = ::Rails.logger
         end
       end

--- a/lib/graphiti/rails/railtie.rb
+++ b/lib/graphiti/rails/railtie.rb
@@ -37,7 +37,11 @@ module Graphiti
 
       initializer "graphti-rails.logger" do
         config.after_initialize do
-          debugger_enabled = ENV.fetch['GRAPHITI_DEBUG'] == 'false' || Graphiti.config.debug
+          puts "=" * 100
+          debugger_enabled = ENV['GRAPHITI_DEBUG'] == 'false' || Graphiti.config.debug
+          puts ENV.fetch['GRAPHITI_DEBUG']
+          puts Graphiti.config.debug
+          puts "=" * 100
           Graphiti.config.debug = debugger_enabled && ::Rails.logger.level.zero?
           Graphiti.logger = ::Rails.logger
         end


### PR DESCRIPTION
I and my team spent quite some time trying to disable Graphiti's logger using the environment variable `GRAPHITI_DEBUG=false` and the configuration block:

```ruby
Graphiti.configure do |config|
  config.debug = false
end
```

But the logger was still printing debug statements because the debugger is forcefully turned on if the Rails debugger level is 0. This change allows the debugger to be turned off.

Complementary PR: https://github.com/graphiti-api/graphiti/pull/174