### PR TITLE
Let the user disable the logger

### DIFF
--- a/lib/graphiti/rails/railtie.rb
+++ b/lib/graphiti/rails/railtie.rb
@@ -37,7 +37,7 @@ module Graphiti
 
       initializer "graphti-rails.logger" do
         config.after_initialize do
-          Graphiti.config.debug = ::Rails.logger.level.zero?
+          Graphiti.config.debug = ::Rails.logger.level.zero? && Graphiti.config.debug
           Graphiti.logger = ::Rails.logger
         end
       end


### PR DESCRIPTION
Allows the debugger to be permanently turned off with the configuration block (as per the documentation):

```ruby
Graphiti.configure do |config|
  config.debug = false
end
```

Complementary PR: https://github.com/graphiti-api/graphiti/pull/175