### PR TITLE
Add option to use `rawid` in generated tests

### DIFF
--- a/lib/generators/graphiti/api_test_generator.rb
+++ b/lib/generators/graphiti/api_test_generator.rb
@@ -13,6 +13,12 @@ module Graphiti
       aliases: ["--actions", "-a"],
       desc: 'Array of controller actions, e.g. "index show destroy"'
 
+    class_option :'rawid',
+      type: :boolean,
+      default: false,
+      aliases: ["--rawid", "-r"],
+      desc: "Generate tests using rawid"
+
     desc "Generates rspec request specs at spec/api"
     def generate
       generate_api_specs

--- a/lib/generators/graphiti/generator_mixin.rb
+++ b/lib/generators/graphiti/generator_mixin.rb
@@ -41,5 +41,19 @@ module Graphiti
       config = graphiti_config.merge(attrs)
       File.open(".graphiticfg.yml", "w") { |f| f.write(config.to_yaml) }
     end
+
+    def id_or_rawid
+      @options["rawid"] ? "rawid" : "id"
+    end
+
+    def sort_raw_ids
+      return unless @options["rawid"]
+      ".sort"
+    end
+
+    def sort_raw_ids_descending
+      return unless @options["rawid"]
+      ".sort.reverse"
+    end
   end
 end

--- a/lib/generators/graphiti/resource_generator.rb
+++ b/lib/generators/graphiti/resource_generator.rb
@@ -14,6 +14,12 @@ module Graphiti
       aliases: ["--omit-comments", "-c"],
       desc: "Generate without documentation comments"
 
+    class_option :'rawid',
+      type: :boolean,
+      default: false,
+      aliases: ["--rawid", "-r"],
+      desc: "Generate tests using rawid"
+
     class_option :actions,
       type: :array,
       default: nil,
@@ -143,12 +149,14 @@ module Graphiti
     def generate_resource_specs
       opts = {}
       opts[:actions] = @options[:actions] if @options[:actions]
+      opts[:rawid] = @options[:rawid] if @options[:rawid]
       invoke "graphiti:resource_test", [resource_klass], opts
     end
 
     def generate_api_specs
       opts = {}
       opts[:actions] = @options[:actions] if @options[:actions]
+      opts[:rawid] = @options[:rawid] if @options[:rawid]
       invoke "graphiti:api_test", [resource_klass], opts
     end
 

--- a/lib/generators/graphiti/templates/index_request_spec.rb.erb
+++ b/lib/generators/graphiti/templates/index_request_spec.rb.erb
@@ -16,7 +16,7 @@ RSpec.describe "<%= type %>#index", type: :request do
       make_request
       expect(response.status).to eq(200), response.body
       expect(d.map(&:jsonapi_type).uniq).to match_array(['<%= type %>'])
-      expect(d.map(&:id)).to match_array([<%= var %>1.id, <%= var %>2.id])
+      expect(d.map(&:<%= id_or_rawid %>)).to match_array([<%= var %>1.id, <%= var %>2.id])
     end
   end
 end

--- a/lib/generators/graphiti/templates/resource_reads_spec.rb.erb
+++ b/lib/generators/graphiti/templates/resource_reads_spec.rb.erb
@@ -7,7 +7,7 @@ RSpec.describe <%= resource_class %>, type: :resource do
     it 'works' do
       render
       data = jsonapi_data[0]
-      expect(data.id).to eq(<%= var %>.id)
+      expect(data.<%= id_or_rawid %>).to eq(<%= var %>.id)
       expect(data.jsonapi_type).to eq('<%= type %>')
       <%- attributes.each do |a| -%>
       <%- if [:created_at, :updated_at].include?(a.name.to_sym) -%>
@@ -31,7 +31,7 @@ RSpec.describe <%= resource_class %>, type: :resource do
 
       it 'works' do
         render
-        expect(d.map(&:id)).to eq([<%= var %>2.id])
+        expect(d.map(&:<%= id_or_rawid %>)).to eq([<%= var %>2.id])
       end
     end
   end
@@ -48,10 +48,10 @@ RSpec.describe <%= resource_class %>, type: :resource do
 
         it 'works' do
           render
-          expect(d.map(&:id)).to eq([
+          expect(d.map(&:<%= id_or_rawid %>)).to eq([
             <%= var %>1.id,
             <%= var %>2.id
-          ])
+          ]<%= sort_raw_ids %>)
         end
       end
 
@@ -62,10 +62,10 @@ RSpec.describe <%= resource_class %>, type: :resource do
 
         it 'works' do
           render
-          expect(d.map(&:id)).to eq([
+          expect(d.map(&:<%= id_or_rawid %>)).to eq([
             <%= var %>2.id,
             <%= var %>1.id
-          ])
+          ]<%= sort_raw_ids_descending %>)
         end
       end
     end

--- a/lib/generators/graphiti/templates/show_request_spec.rb.erb
+++ b/lib/generators/graphiti/templates/show_request_spec.rb.erb
@@ -15,7 +15,7 @@ RSpec.describe "<%= type %>#show", type: :request do
       make_request
       expect(response.status).to eq(200)
       expect(d.jsonapi_type).to eq('<%= type %>')
-      expect(d.id).to eq(<%= var %>.id)
+      expect(d.<%= id_or_rawid %>).to eq(<%= var %>.id)
     end
   end
 end


### PR DESCRIPTION
We use uuids for our models, and when generating new resources, we have to manually fix them to get them passing.

This commit adds an option to the generator to use `GraphitiSpecHelpers::Node#rawid` instead of `GraphitiSpecHelpers::Node#id`.

Specify `--rawid` option when using the graphiti generator, e.g.

```
rails g graphiti:resource Account --model Account --rawid
```