### PR TITLE
Add namespace option to resource generator for controllers

### DIFF
--- a/lib/generators/graphiti/templates/controller.rb.erb
+++ b/lib/generators/graphiti/templates/controller.rb.erb
@@ -1,5 +1,5 @@
 <% module_namespacing do -%>
-class <%= model_klass.name.pluralize %>Controller < ApplicationController
+class <%= controller_klass %> < ApplicationController
   <%- if actions?('index') -%>
   def index
     <%= file_name.pluralize %> = <%= resource_klass %>.all(params)


### PR DESCRIPTION
* Added option "--namespace" to *resource generator* to namespace controllers
  `rails g graphiti:resource  ....  --namespace]`
* Automatically add resource routes under namespace
 ```
  scope path: ApplicationResource.endpoint_namespace, defaults: { format: :jsonapi } do
    scope module: 'api/v1', as: 'api' do
      resources :employees
    end
  end 
```
* Added _'api'_ prefix to resource routes
  
