### PR TITLE
feat: rake task option for authorisation token

### DIFF
--- a/lib/tasks/graphiti.rake
+++ b/lib/tasks/graphiti.rake
@@ -22,7 +22,10 @@ namespace :graphiti do
     end
     path = "#{path}&debug=true" if debug
     handle_request_exceptions do
-      session.get(path.to_s)
+      headers = {
+        "Authorization": ENV['AUTHORIZATION_HEADER']
+      }.compact
+      session.get(path.to_s, headers: headers)
     end
     JSON.parse(session.response.body)
   end


### PR DESCRIPTION
e.g.:
```
$ AUTHORIZATION_HEADER="Basic --BASE64_PASSWORD--" bin/rake graphiti:request[/v1/events]
$ AUTHORIZATION_HEADER="Bearer --PRIVATE_TOKEN--" bin/rake graphiti:request[/v1/events]
$ AUTHORIZATION_HEADER="Token --PRIVATE_API_KEY--" bin/rake graphiti:request[/v1/events]
```

todo:
- [ ] update https://www.graphiti.dev/guides/concepts/debugging#debugger