### PR TITLE
Fix rake task helpers polluting global namespace

### DIFF
--- a/lib/tasks/graphiti.rake
+++ b/lib/tasks/graphiti.rake
@@ -1,54 +1,62 @@
 namespace :graphiti do
-  include RescueRegistry::RailsTestHelpers
+  module Graphiti
+    module Rails
+      module RakeHelpers
+        extend RescueRegistry::RailsTestHelpers
 
-  def session
-    @session ||= ActionDispatch::Integration::Session.new(Rails.application)
-  end
+        module_function
 
-  def setup_rails!
-    Rails.application.eager_load!
-    Rails.application.config.cache_classes = true
-    Rails.application.config.action_controller.perform_caching = false
-  end
+        def session
+          @session ||= ActionDispatch::Integration::Session.new(::Rails.application)
+        end
 
-  def make_request(path, debug = false)
-    if path.split("/").length == 2
-      path = "#{ApplicationResource.endpoint_namespace}#{path}"
+        def setup_rails!
+          ::Rails.application.eager_load!
+          ::Rails.application.config.cache_classes = true
+          ::Rails.application.config.action_controller.perform_caching = false
+        end
+
+        def make_request(path, debug = false)
+          if path.split("/").length == 2
+            path = "#{ApplicationResource.endpoint_namespace}#{path}"
+          end
+          path << if path.include?("?")
+            "&cache=bust"
+          else
+            "?cache=bust"
+          end
+          path = "#{path}&debug=true" if debug
+          handle_request_exceptions do
+            headers = {
+              "Authorization": ENV['AUTHORIZATION_HEADER']
+            }.compact
+            session.get(path.to_s, headers: headers)
+          end
+          JSON.parse(session.response.body)
+        end
+      end
     end
-    path << if path.include?("?")
-      "&cache=bust"
-    else
-      "?cache=bust"
-    end
-    path = "#{path}&debug=true" if debug
-    handle_request_exceptions do
-      headers = {
-        "Authorization": ENV['AUTHORIZATION_HEADER']
-      }.compact
-      session.get(path.to_s, headers: headers)
-    end
-    JSON.parse(session.response.body)
   end
 
   desc "Execute request without web server."
   task :request, [:path, :debug] => [:environment] do |_, args|
-    setup_rails!
+    Graphiti::Rails::RakeHelpers.setup_rails!
     Graphiti.logger = Graphiti.stdout_logger
     Graphiti::Debugger.preserve = true
     require "pp"
     path, debug = args[:path], args[:debug]
     puts "Graphiti Request: #{path}"
-    json = make_request(path, debug)
+    json = Graphiti::Rails::RakeHelpers.make_request(path, debug)
     pp json
     Graphiti::Debugger.flush if debug
   end
 
   desc "Execute benchmark without web server."
   task :benchmark, [:path, :requests] => [:environment] do |_, args|
-    setup_rails!
+    Graphiti::Rails::RakeHelpers.setup_rails!
     took = Benchmark.ms {
       args[:requests].to_i.times do
-        make_request(args[:path])
+        Graphiti::Rails::RakeHelpers.make_request(args[:path])
       end
     }
     puts "Took: #{(took / args[:requests].to_f).round(2)}ms"


### PR DESCRIPTION
Before, the `session` method (for example) would be redefined in the
context of an RSpec request spec because the default definee in the
block within the `namespace` call would be `main`, the global object.

Additional context about default definees:
https://blog.yugui.jp/entry/846