### PR TITLE
Specs fail because an rspec double is leaking across tests

### DIFF
--- a/spec/unit/railtie_spec.rb
+++ b/spec/unit/railtie_spec.rb
@@ -1,4 +1,5 @@
 # TODO: Write proper specs
+require "rails_helper"
 
 RSpec.describe Graphiti::Rails::Railtie do
   describe "when rails is defined with logger" do

--- a/spec/unit/railtie_spec.rb
+++ b/spec/unit/railtie_spec.rb
@@ -2,6 +2,15 @@
 require "rails_helper"
 
 RSpec.describe Graphiti::Rails::Railtie do
+  before do
+    stub_const("::Rails", rails)
+    Graphiti.instance_variable_set(:@config, nil)
+  end
+
+  after do
+    Graphiti.instance_variable_set(:@config, nil)
+  end
+
   describe "when rails is defined with logger" do
     let(:rails) do
       logger = OpenStruct.new(level: 1)
@@ -10,15 +19,6 @@ RSpec.describe Graphiti::Rails::Railtie do
       end
 
       double(root: Pathname.new("/foo/bar"), logger: logger)
-    end
-
-    before do
-      stub_const("::Rails", rails)
-      Graphiti.instance_variable_set(:@config, nil)
-    end
-
-    after do
-      Graphiti.instance_variable_set(:@config, nil)
     end
 
     describe "#schema_path" do
@@ -51,11 +51,7 @@ RSpec.describe Graphiti::Rails::Railtie do
   end
 
   context "when Rails is defined without logger" do
-    before do
-      rails = double(root: Pathname.new("/foo/bar"), logger: double.as_null_object)
-      stub_const("::Rails", rails)
-      Graphiti.instance_variable_set(:@config, nil)
-    end
+    let(:rails) { stub_const("::Rails", double(root: Pathname.new("/foo/bar"), logger: nil)) }
 
     it "defaults" do
       expect(Graphiti.config.schema_path.to_s)


### PR DESCRIPTION
The `Rails.logger` double (via `as_null_object`) is leaking across tests. It is pulled from `::Rails` and set as `::Graphiti.logger` which, as a constant, persists across specs.

This resets Graphiti's config after the railtie specs which stub on it.

Also, the railtie test can't run without configuring rspec (via some helpers) and loading the Railtie under test. Ideally we'd use a slimmed-down spec_helper for configuring just rspec (without rails). However, that doesn't already exist, and we'd need some form of autoloading anyway; so for the time being we just use the existing rails_helper.