### PR TITLE
Stringify path if Rails version > 7

### DIFF
--- a/lib/graphiti/rails/railtie.rb
+++ b/lib/graphiti/rails/railtie.rb
@@ -131,8 +131,12 @@ module Graphiti
           end
 
           route = begin
+                    if Gem::Version.new(::Rails::VERSION::STRING) > Gem::Version.new("7.0.0")
+                      path = path.to_s
+                    end
                     ::Rails.application.routes.recognize_path(path, method: method)
-                  rescue
+                  rescue => e
+                    binding.pry
                     nil
                   end
           "#{route[:controller]}_controller".classify.safe_constantize if route

--- a/lib/graphiti/rails/railtie.rb
+++ b/lib/graphiti/rails/railtie.rb
@@ -131,12 +131,11 @@ module Graphiti
           end
 
           route = begin
-                    if Gem::Version.new(::Rails::VERSION::STRING) > Gem::Version.new("7.0.0")
+                    if Gem::Version.new(::Rails::VERSION::STRING) >= Gem::Version.new("7.0.0")
                       path = path.to_s
                     end
                     ::Rails.application.routes.recognize_path(path, method: method)
                   rescue => e
-                    binding.pry
                     nil
                   end
           "#{route[:controller]}_controller".classify.safe_constantize if route


### PR DESCRIPTION
Calling recognize_path with a path that is a symbol will result in a:

```
NoMethodError: undefined method `include?' for an instance of Symbol
```

This results in a nil value being returned which leads to this error for the developer:

```
Graphiti::Errors::InvalidLink:
  Api::V2::GymResource: Cannot link to sideload :my_resource!

  Make sure the endpoint "/api/v2/my_resource" exists with action :index, or customize the endpoint for Api::V2::MyResource.

  If you do not wish to generate a link, pass link: false or set
  self.autolink = false.
```