### PR TITLE
🐛 Fix bug: `register_parameter_parser` overiding custom config

### DIFF
--- a/lib/graphiti/rails/railtie.rb
+++ b/lib/graphiti/rails/railtie.rb
@@ -72,9 +72,9 @@ module Graphiti
 
       def register_parameter_parser
         if ::Rails::VERSION::MAJOR >= 5
-          ActionDispatch::Request.parameter_parsers[:jsonapi] = PARSER
+          ActionDispatch::Request.parameter_parsers[:jsonapi] ||= PARSER
         else
-          ActionDispatch::ParamsParser::DEFAULT_PARSERS[Mime[:jsonapi]] = PARSER
+          ActionDispatch::ParamsParser::DEFAULT_PARSERS[Mime[:jsonapi]] ||= PARSER
         end
       end
 


### PR DESCRIPTION
## Description

Closes: https://github.com/graphiti-api/graphiti-rails/issues/106